### PR TITLE
Firebase 인증 방식 파일 경로에서 환경변수로 변경

### DIFF
--- a/src/main/kotlin/com/example/team/haribo/goms/global/config/FirebaseConfig.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/global/config/FirebaseConfig.kt
@@ -6,19 +6,20 @@ import com.google.firebase.FirebaseOptions
 import jakarta.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
-import java.io.FileInputStream
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
 
 @Configuration
 class FirebaseConfig(
-    @Value("\${fcm.credentials-path}")
-    private val credentialsPath: String
+    @Value("\${fcm.credentials-json}")
+    private val credentialsJson: String
 ) {
 
     @PostConstruct
     fun init() {
         if (FirebaseApp.getApps().isNotEmpty()) return
 
-        val credentials = FileInputStream(credentialsPath).use {
+        val credentials = ByteArrayInputStream(credentialsJson.toByteArray(StandardCharsets.UTF_8)).use {
             GoogleCredentials.fromStream(it)
         }
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -40,4 +40,4 @@ jwt:
   refresh-exp-seconds: ${JWT_REFRESH_EXP_SECONDS:1209600}
 
 fcm:
-  credentials-path: ${FCM_CREDENTIALS_PATH}
+  credentials-json: ${FCM_CREDENTIALS_JSON}


### PR DESCRIPTION
## 📃 작업내용
기존 Firebase SDK 인증을 로컬 시크릿 파일로 관리하던 부분을 원활한 Cloudtype 배포를 위하여
Json 자체를 환경변수로써 사용하는 방식으로 변경하였습니다
## 🙋‍♂️ 참고사항

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?