### PR TITLE
외출 학생 목록 조회 응답에 memberId 필드 추가

### DIFF
--- a/src/main/kotlin/com/example/team/haribo/goms/domain/outing/dto/response/OutingStudentResponse.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/outing/dto/response/OutingStudentResponse.kt
@@ -3,8 +3,9 @@ package com.example.team.haribo.goms.domain.outing.dto.response
 import java.time.LocalDateTime
 
 data class OutingStudentResponse(
+    val memberId: Long,
     val name: String,
-    val grade: Long,
+    val grade: Int,
     val department: String,
     val outingAt: LocalDateTime
 )

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/OutingStudentListServiceImpl.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/OutingStudentListServiceImpl.kt
@@ -15,14 +15,17 @@ class OutingStudentListServiceImpl(
     @Transactional(readOnly = true)
     override fun getList(): OutingStudentListResponse {
         val outings = outingRepository.findAllActiveWithMember()
-        val students = outings.map {
-            OutingStudentResponse(
-                name = it.member.name,
-                grade = it.member.grade.toLong(),
-                department = it.member.department.name,
-                outingAt = it.outingAt
-            )
-        }
-        return OutingStudentListResponse(students)
+
+        return OutingStudentListResponse(
+            students = outings.map {
+                OutingStudentResponse(
+                    memberId = requireNotNull(it.member.id) { "member.id must not be null" },
+                    name = it.member.name,
+                    grade = it.member.grade,
+                    department = it.member.department.name,
+                    outingAt = it.outingAt
+                )
+            }
+        )
     }
 }

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/OutingStudentSearchServiceImpl.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/OutingStudentSearchServiceImpl.kt
@@ -4,6 +4,7 @@ import com.example.team.haribo.goms.domain.outing.dto.response.OutingStudentList
 import com.example.team.haribo.goms.domain.outing.dto.response.OutingStudentResponse
 import com.example.team.haribo.goms.domain.outing.repository.OutingRepository
 import com.example.team.haribo.goms.domain.outing.service.OutingStudentSearchService
+import com.example.team.haribo.goms.domain.outing.exception.EmptyNameException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -14,7 +15,11 @@ class OutingStudentSearchServiceImpl(
 
     @Transactional(readOnly = true)
     override fun search(name: String?): OutingStudentListResponse {
-        val outings = outingRepository.searchActiveWithMemberByName(name ?: "")
+        if (name.isNullOrBlank()) {
+            throw EmptyNameException()
+        }
+
+        val outings = outingRepository.searchActiveWithMemberByName(name)
 
         return OutingStudentListResponse(
             students = outings.map {

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/OutingStudentSearchServiceImpl.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/OutingStudentSearchServiceImpl.kt
@@ -2,7 +2,6 @@ package com.example.team.haribo.goms.domain.outing.service.impl
 
 import com.example.team.haribo.goms.domain.outing.dto.response.OutingStudentListResponse
 import com.example.team.haribo.goms.domain.outing.dto.response.OutingStudentResponse
-import com.example.team.haribo.goms.domain.outing.exception.EmptyNameException
 import com.example.team.haribo.goms.domain.outing.repository.OutingRepository
 import com.example.team.haribo.goms.domain.outing.service.OutingStudentSearchService
 import org.springframework.stereotype.Service
@@ -15,20 +14,18 @@ class OutingStudentSearchServiceImpl(
 
     @Transactional(readOnly = true)
     override fun search(name: String?): OutingStudentListResponse {
-        val keyword = name?.trim()
-        if (keyword.isNullOrEmpty()) {
-            throw EmptyNameException()
-        }
+        val outings = outingRepository.searchActiveWithMemberByName(name ?: "")
 
-        val outings = outingRepository.searchActiveWithMemberByName(keyword)
-        val students = outings.map {
-            OutingStudentResponse(
-                name = it.member.name,
-                grade = it.member.grade.toLong(),
-                department = it.member.department.name,
-                outingAt = it.outingAt
-            )
-        }
-        return OutingStudentListResponse(students)
+        return OutingStudentListResponse(
+            students = outings.map {
+                OutingStudentResponse(
+                    memberId = requireNotNull(it.member.id) { "member.id must not be null" },
+                    name = it.member.name,
+                    grade = it.member.grade,
+                    department = it.member.department.name,
+                    outingAt = it.outingAt
+                )
+            }
+        )
     }
 }


### PR DESCRIPTION
## 📃 작업내용
외출 학색 목록 조회, 검색 API의 응답 필드에 `memberId`를 추가하였습니다.
## 🙋‍♂️ 참고사항

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?