### PR TITLE
내 상태 조회 응답 필드에 지각 횟수 추가

### DIFF
--- a/src/main/kotlin/com/example/team/haribo/goms/domain/late/repository/LateRepository.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/late/repository/LateRepository.kt
@@ -37,7 +37,7 @@ interface LateRepository : JpaRepository<Late, Long> {
     )
     fun findAllByComingAtRangeWithMember(start: LocalDateTime, end: LocalDateTime): List<Late>
 
-    fun countByMember_Id(memberId: Long): Long
+    fun countByMemberId(memberId: Long): Long
 
-    fun deleteAllByMember_Id(memberId: Long): Long
+    fun deleteAllByMemberId(memberId: Long): Long
 }

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/late/repository/LateRepository.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/late/repository/LateRepository.kt
@@ -37,5 +37,7 @@ interface LateRepository : JpaRepository<Late, Long> {
     )
     fun findAllByComingAtRangeWithMember(start: LocalDateTime, end: LocalDateTime): List<Late>
 
+    fun countByMember_Id(memberId: Long): Long
+
     fun deleteAllByMember_Id(memberId: Long): Long
 }

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/member/service/impl/MemberWithdrawServiceImpl.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/member/service/impl/MemberWithdrawServiceImpl.kt
@@ -61,7 +61,7 @@ class MemberWithdrawServiceImpl(
 
         reviewReportRepository.deleteAllByMemberId(memberId)
         reviewReportRepository.deleteAllByReview_Member_Id(memberId)
-        lateRepository.deleteAllByMember_Id(memberId)
+        lateRepository.deleteAllByMemberId(memberId)
         reviewRepository.deleteAllByMember_Id(memberId)
         placeRecommendRepository.deleteAllByMember_Id(memberId)
         outingRepository.deleteAllByMember_Id(memberId)

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/outing/dto/response/MyOutingStatusResponse.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/outing/dto/response/MyOutingStatusResponse.kt
@@ -7,5 +7,6 @@ data class MyOutingStatusResponse(
     val status: Status,
     val name: String,
     val grade: Int,
-    val department: String
+    val department: String,
+    val lateCount: Long
 )

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/MyOutingStatusServiceImpl.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/MyOutingStatusServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.example.team.haribo.goms.domain.outing.service.impl
 
+import com.example.team.haribo.goms.domain.late.repository.LateRepository
 import com.example.team.haribo.goms.domain.outing.dto.response.MyOutingStatusResponse
 import com.example.team.haribo.goms.domain.outing.service.MyOutingStatusService
 import com.example.team.haribo.goms.global.util.MemberUtil
@@ -8,19 +9,22 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class MyOutingStatusServiceImpl(
-    private val memberUtil: MemberUtil
+    private val memberUtil: MemberUtil,
+    private val lateRepository: LateRepository
 ) : MyOutingStatusService {
 
     @Transactional(readOnly = true)
     override fun getStatus(): MyOutingStatusResponse {
         val member = memberUtil.currentMember()
+        val lateCount = lateRepository.countByMember_Id(member.id!!)
 
         return MyOutingStatusResponse(
             memberId = member.id!!,
             status = member.status,
             name = member.name,
             grade = member.grade,
-            department = member.department.name
+            department = member.department.name,
+            lateCount = lateCount
         )
     }
 }

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/MyOutingStatusServiceImpl.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/MyOutingStatusServiceImpl.kt
@@ -16,10 +16,11 @@ class MyOutingStatusServiceImpl(
     @Transactional(readOnly = true)
     override fun getStatus(): MyOutingStatusResponse {
         val member = memberUtil.currentMember()
-        val lateCount = lateRepository.countByMember_Id(member.id!!)
+        val memberId = member.id!!
+        val lateCount = lateRepository.countByMemberId(memberId)
 
         return MyOutingStatusResponse(
-            memberId = member.id!!,
+            memberId = memberId,
             status = member.status,
             name = member.name,
             grade = member.grade,

--- a/src/test/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/MyOutingStatusServiceImplTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/MyOutingStatusServiceImplTest.kt
@@ -1,6 +1,7 @@
 package com.example.team.haribo.goms.domain.outing.service.impl
 
 import com.example.team.haribo.goms.domain.common.enums.Status
+import com.example.team.haribo.goms.domain.late.repository.LateRepository
 import com.example.team.haribo.goms.fixture.MemberFixture
 import com.example.team.haribo.goms.global.util.MemberUtil
 import io.kotest.core.spec.style.DescribeSpec
@@ -11,29 +12,40 @@ import io.mockk.mockk
 class MyOutingStatusServiceImplTest : DescribeSpec({
 
     val memberUtil = mockk<MemberUtil>()
-    val service = MyOutingStatusServiceImpl(memberUtil)
+    val lateRepository = mockk<LateRepository>()
+    val service = MyOutingStatusServiceImpl(memberUtil, lateRepository)
 
     describe("MyOutingStatusService") {
 
         context("Given: COMING 상태 멤버") {
             val member = MemberFixture.student(status = Status.COMING)
             every { memberUtil.currentMember() } returns member
+            every { lateRepository.countByMember_Id(member.id!!) } returns 0L
 
             it("When: 외출 상태 조회 시 Then: COMING 상태를 반환한다") {
                 val response = service.getStatus()
                 response.status shouldBe Status.COMING
                 response.memberId shouldBe member.id!!
                 response.name shouldBe member.name
+                response.grade shouldBe member.grade
+                response.department shouldBe member.department.name
+                response.lateCount shouldBe 0L
             }
         }
 
         context("Given: OUTING 상태 멤버") {
             val member = MemberFixture.outing()
             every { memberUtil.currentMember() } returns member
+            every { lateRepository.countByMember_Id(member.id!!) } returns 2L
 
             it("When: 외출 상태 조회 시 Then: OUTING 상태를 반환한다") {
                 val response = service.getStatus()
                 response.status shouldBe Status.OUTING
+                response.memberId shouldBe member.id!!
+                response.name shouldBe member.name
+                response.grade shouldBe member.grade
+                response.department shouldBe member.department.name
+                response.lateCount shouldBe 2L
             }
         }
     }

--- a/src/test/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/MyOutingStatusServiceImplTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/MyOutingStatusServiceImplTest.kt
@@ -20,7 +20,7 @@ class MyOutingStatusServiceImplTest : DescribeSpec({
         context("Given: COMING 상태 멤버") {
             val member = MemberFixture.student(status = Status.COMING)
             every { memberUtil.currentMember() } returns member
-            every { lateRepository.countByMember_Id(member.id!!) } returns 0L
+            every { lateRepository.countByMemberId(member.id!!) } returns 0L
 
             it("When: 외출 상태 조회 시 Then: COMING 상태를 반환한다") {
                 val response = service.getStatus()
@@ -36,7 +36,7 @@ class MyOutingStatusServiceImplTest : DescribeSpec({
         context("Given: OUTING 상태 멤버") {
             val member = MemberFixture.outing()
             every { memberUtil.currentMember() } returns member
-            every { lateRepository.countByMember_Id(member.id!!) } returns 2L
+            every { lateRepository.countByMemberId(member.id!!) } returns 2L
 
             it("When: 외출 상태 조회 시 Then: OUTING 상태를 반환한다") {
                 val response = service.getStatus()


### PR DESCRIPTION
## 📃 작업내용
`GET api/v3/outing/status`의 필드에 `lateCount`를 추가하였습니다.
## 🙋‍♂️ 참고사항

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?