### PR TITLE
카카오 장소 동기화를 분할 검색 기반으로 변경

### DIFF
--- a/src/main/kotlin/com/example/team/haribo/goms/domain/place/client/KakaoPlaceClient.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/place/client/KakaoPlaceClient.kt
@@ -33,6 +33,7 @@ class KakaoPlaceClient(
                     .queryParam("radius", radius)
                     .queryParam("page", page)
                     .queryParam("size", size)
+                    .queryParam("sort", "distance")
                     .build()
             }
             .header("Authorization", "KakaoAK $restApiKey")

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/place/dto/response/PlaceSyncResult.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/place/dto/response/PlaceSyncResult.kt
@@ -4,5 +4,7 @@ data class PlaceSyncResult(
     val createdCount: Int,
     val updatedCount: Int,
     val deactivatedCount: Int,
-    val totalFetchedCount: Int
+    val totalFetchedCount: Int,
+    val searchPointCount: Int,
+    val rawCollectedCount: Int
 )

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/place/service/impl/PlaceSyncServiceImpl.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/place/service/impl/PlaceSyncServiceImpl.kt
@@ -1,10 +1,10 @@
 package com.example.team.haribo.goms.domain.place.service.impl
 
+import com.example.team.haribo.goms.domain.common.enums.PlaceSyncCategory
 import com.example.team.haribo.goms.domain.place.client.KakaoPlaceClient
 import com.example.team.haribo.goms.domain.place.dto.response.KakaoPlaceDocument
 import com.example.team.haribo.goms.domain.place.dto.response.PlaceSyncResult
 import com.example.team.haribo.goms.domain.place.entity.Place
-import com.example.team.haribo.goms.domain.common.enums.PlaceSyncCategory
 import com.example.team.haribo.goms.domain.place.repository.PlaceRepository
 import com.example.team.haribo.goms.domain.place.service.PlaceSyncService
 import com.example.team.haribo.goms.domain.place.util.PlaceDistanceCalculator
@@ -31,9 +31,10 @@ class PlaceSyncServiceImpl(
     private val schoolLatitude = 35.1427689679488
     private val schoolLongitude = 126.800771954215
     private val finalRadius = 1000
-    private val searchRadius = 400
-    private val searchPointOffsetMeter = 300.0
+    private val searchRadius = 500
+    private val searchPointOffsetMeter = 500.0
     private val pageSize = 15
+    private val maxPage = 3
 
     @Transactional
     override fun sync(): PlaceSyncResult {
@@ -126,7 +127,7 @@ class PlaceSyncServiceImpl(
             searchPoints.forEach { point ->
                 var page = 1
 
-                while (true) {
+                while (page <= maxPage) {
                     val response = kakaoPlaceClient.searchByCategory(
                         categoryGroupCode = category.categoryGroupCode,
                         x = point.longitude.toString(),
@@ -140,6 +141,7 @@ class PlaceSyncServiceImpl(
 
                     response.documents
                         .filter { placeSyncFilter.isAllowed(it) }
+                        .filter { !result.containsKey(it.id) }
                         .filter { isWithinSchoolRadius(it) }
                         .forEach { result[it.id] = it }
 

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/place/service/impl/PlaceSyncServiceImpl.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/place/service/impl/PlaceSyncServiceImpl.kt
@@ -7,7 +7,10 @@ import com.example.team.haribo.goms.domain.place.entity.Place
 import com.example.team.haribo.goms.domain.common.enums.PlaceSyncCategory
 import com.example.team.haribo.goms.domain.place.repository.PlaceRepository
 import com.example.team.haribo.goms.domain.place.service.PlaceSyncService
+import com.example.team.haribo.goms.domain.place.util.PlaceDistanceCalculator
+import com.example.team.haribo.goms.domain.place.util.PlaceSearchPointGenerator
 import com.example.team.haribo.goms.domain.place.util.PlaceSyncFilter
+import com.example.team.haribo.goms.domain.place.util.SearchPoint
 import com.example.team.haribo.goms.global.log.LogFormat
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -18,25 +21,36 @@ import java.time.LocalDateTime
 class PlaceSyncServiceImpl(
     private val kakaoPlaceClient: KakaoPlaceClient,
     private val placeRepository: PlaceRepository,
-    private val placeSyncFilter: PlaceSyncFilter
+    private val placeSyncFilter: PlaceSyncFilter,
+    private val placeSearchPointGenerator: PlaceSearchPointGenerator,
+    private val placeDistanceCalculator: PlaceDistanceCalculator
 ) : PlaceSyncService {
 
     private val log = LoggerFactory.getLogger(PlaceSyncServiceImpl::class.java)
 
-    private val schoolLatitude = "35.1427689679488"
-    private val schoolLongitude = "126.800771954215"
-    private val radius = 1500
+    private val schoolLatitude = 35.1427689679488
+    private val schoolLongitude = 126.800771954215
+    private val finalRadius = 1000
+    private val searchRadius = 400
+    private val searchPointOffsetMeter = 300.0
     private val pageSize = 15
 
     @Transactional
     override fun sync(): PlaceSyncResult {
         val syncStartedAt = LocalDateTime.now()
-        val documents = fetchAllDocuments()
+        val searchPoints = placeSearchPointGenerator.generate(
+            centerLatitude = schoolLatitude,
+            centerLongitude = schoolLongitude,
+            offsetMeter = searchPointOffsetMeter,
+            searchRadius = searchRadius
+        )
+
+        val fetchResult = fetchAllDocuments(searchPoints)
 
         var createdCount = 0
         var updatedCount = 0
 
-        documents.forEach { document ->
+        fetchResult.documents.forEach { document ->
             val existing = placeRepository.findByExternalPlaceId(document.id).orElse(null)
 
             if (existing == null) {
@@ -85,10 +99,12 @@ class PlaceSyncServiceImpl(
             LogFormat.message(
                 domain = "PLACE",
                 event = "장소 동기화 완료",
+                "searchPointCount" to searchPoints.size,
+                "rawCollectedCount" to fetchResult.rawCollectedCount,
+                "totalFetchedCount" to fetchResult.documents.size,
                 "createdCount" to createdCount,
                 "updatedCount" to updatedCount,
-                "deactivatedCount" to placesToDeactivate.size,
-                "totalFetchedCount" to documents.size
+                "deactivatedCount" to placesToDeactivate.size
             )
         )
 
@@ -96,35 +112,61 @@ class PlaceSyncServiceImpl(
             createdCount = createdCount,
             updatedCount = updatedCount,
             deactivatedCount = placesToDeactivate.size,
-            totalFetchedCount = documents.size
+            totalFetchedCount = fetchResult.documents.size,
+            searchPointCount = searchPoints.size,
+            rawCollectedCount = fetchResult.rawCollectedCount
         )
     }
 
-    private fun fetchAllDocuments(): List<KakaoPlaceDocument> {
+    private fun fetchAllDocuments(searchPoints: List<SearchPoint>): FetchResult {
         val result = linkedMapOf<String, KakaoPlaceDocument>()
+        var rawCollectedCount = 0
 
         PlaceSyncCategory.entries.forEach { category ->
-            var page = 1
+            searchPoints.forEach { point ->
+                var page = 1
 
-            while (true) {
-                val response = kakaoPlaceClient.searchByCategory(
-                    categoryGroupCode = category.categoryGroupCode,
-                    x = schoolLongitude,
-                    y = schoolLatitude,
-                    radius = radius,
-                    page = page,
-                    size = pageSize
-                )
+                while (true) {
+                    val response = kakaoPlaceClient.searchByCategory(
+                        categoryGroupCode = category.categoryGroupCode,
+                        x = point.longitude.toString(),
+                        y = point.latitude.toString(),
+                        radius = point.radius,
+                        page = page,
+                        size = pageSize
+                    )
 
-                response.documents
-                    .filter { placeSyncFilter.isAllowed(it) }
-                    .forEach { result[it.id] = it }
+                    rawCollectedCount += response.documents.size
 
-                if (response.meta.is_end) break
-                page++
+                    response.documents
+                        .filter { placeSyncFilter.isAllowed(it) }
+                        .filter { isWithinSchoolRadius(it) }
+                        .forEach { result[it.id] = it }
+
+                    if (response.meta.is_end) break
+                    page++
+                }
             }
         }
 
-        return result.values.toList()
+        return FetchResult(
+            documents = result.values.toList(),
+            rawCollectedCount = rawCollectedCount
+        )
     }
+
+    private fun isWithinSchoolRadius(document: KakaoPlaceDocument): Boolean {
+        return placeDistanceCalculator.isWithinRadius(
+            originLatitude = schoolLatitude,
+            originLongitude = schoolLongitude,
+            targetLatitude = document.y.toDouble(),
+            targetLongitude = document.x.toDouble(),
+            radiusMeter = finalRadius
+        )
+    }
+
+    private data class FetchResult(
+        val documents: List<KakaoPlaceDocument>,
+        val rawCollectedCount: Int
+    )
 }

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/place/util/PlaceDistanceCalculator.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/place/util/PlaceDistanceCalculator.kt
@@ -1,0 +1,48 @@
+package com.example.team.haribo.goms.domain.place.util
+
+import org.springframework.stereotype.Component
+import kotlin.math.asin
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+@Component
+class PlaceDistanceCalculator {
+
+    fun isWithinRadius(
+        originLatitude: Double,
+        originLongitude: Double,
+        targetLatitude: Double,
+        targetLongitude: Double,
+        radiusMeter: Int
+    ): Boolean {
+        return distanceMeter(
+            originLatitude = originLatitude,
+            originLongitude = originLongitude,
+            targetLatitude = targetLatitude,
+            targetLongitude = targetLongitude
+        ) <= radiusMeter
+    }
+
+    fun distanceMeter(
+        originLatitude: Double,
+        originLongitude: Double,
+        targetLatitude: Double,
+        targetLongitude: Double
+    ): Double {
+        val earthRadiusMeter = 6_371_000.0
+
+        val latitudeDelta = Math.toRadians(targetLatitude - originLatitude)
+        val longitudeDelta = Math.toRadians(targetLongitude - originLongitude)
+        val originLatitudeRad = Math.toRadians(originLatitude)
+        val targetLatitudeRad = Math.toRadians(targetLatitude)
+
+        val a = sin(latitudeDelta / 2).pow(2) +
+                cos(originLatitudeRad) * cos(targetLatitudeRad) * sin(longitudeDelta / 2).pow(2)
+
+        val c = 2 * asin(sqrt(a))
+
+        return earthRadiusMeter * c
+    }
+}

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/place/util/PlaceSearchPointGenerator.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/place/util/PlaceSearchPointGenerator.kt
@@ -1,0 +1,40 @@
+package com.example.team.haribo.goms.domain.place.util
+
+import org.springframework.stereotype.Component
+import kotlin.math.cos
+
+@Component
+class PlaceSearchPointGenerator {
+
+    fun generate(
+        centerLatitude: Double,
+        centerLongitude: Double,
+        offsetMeter: Double,
+        searchRadius: Int
+    ): List<SearchPoint> {
+        val northLatitude = moveLatitude(centerLatitude, offsetMeter)
+        val southLatitude = moveLatitude(centerLatitude, -offsetMeter)
+        val eastLongitude = moveLongitude(centerLatitude, centerLongitude, offsetMeter)
+        val westLongitude = moveLongitude(centerLatitude, centerLongitude, -offsetMeter)
+
+        return listOf(
+            SearchPoint(centerLongitude, centerLatitude, searchRadius),
+            SearchPoint(centerLongitude, northLatitude, searchRadius),
+            SearchPoint(centerLongitude, southLatitude, searchRadius),
+            SearchPoint(eastLongitude, centerLatitude, searchRadius),
+            SearchPoint(westLongitude, centerLatitude, searchRadius),
+            SearchPoint(eastLongitude, northLatitude, searchRadius),
+            SearchPoint(westLongitude, northLatitude, searchRadius),
+            SearchPoint(eastLongitude, southLatitude, searchRadius),
+            SearchPoint(westLongitude, southLatitude, searchRadius)
+        )
+    }
+
+    private fun moveLatitude(latitude: Double, meter: Double): Double {
+        return latitude + (meter / 111_320.0)
+    }
+
+    private fun moveLongitude(latitude: Double, longitude: Double, meter: Double): Double {
+        return longitude + (meter / (111_320.0 * cos(Math.toRadians(latitude))))
+    }
+}

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/place/util/SearchPoint.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/place/util/SearchPoint.kt
@@ -1,0 +1,7 @@
+package com.example.team.haribo.goms.domain.place.util
+
+data class SearchPoint(
+    val longitude: Double,
+    val latitude: Double,
+    val radius: Int
+)


### PR DESCRIPTION
## 📃 작업내용
기존에 학교 좌표 기준 반경 1500m를 동기화하는 로직을 1000m로 변경하고 장소가 누락되는 문제를 해결하기 위해 반경 1000m를 여러 부분으로 쪼개 동기화하여 누락되는 장소를 최소화 하도록 변경했습니다.
## 🙋‍♂️ 참고사항

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?