### PR TITLE
지각 자동 생성 로직 추가

### DIFF
--- a/src/main/kotlin/com/example/team/haribo/goms/domain/late/job/LateAutoCreateJob.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/late/job/LateAutoCreateJob.kt
@@ -1,0 +1,56 @@
+package com.example.team.haribo.goms.domain.late.job
+
+import com.example.team.haribo.goms.domain.common.enums.Status
+import com.example.team.haribo.goms.domain.late.entity.Late
+import com.example.team.haribo.goms.domain.late.repository.LateRepository
+import com.example.team.haribo.goms.domain.outing.repository.OutingRepository
+import com.example.team.haribo.goms.global.log.LogFormat
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@Component
+class LateAutoCreateJob(
+    private val outingRepository: OutingRepository,
+    private val lateRepository: LateRepository
+) {
+
+    private val log = LoggerFactory.getLogger(LateAutoCreateJob::class.java)
+
+    @Transactional
+    @Scheduled(cron = "0 30 19 * * MON,WED", zone = "Asia/Seoul")
+    fun createLatesForOutingMembers() {
+        val start = System.currentTimeMillis()
+        val now = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+
+        val activeOutings = outingRepository.findAllActiveWithOutingMember()
+        val lates = activeOutings
+            .filterNot { lateRepository.existsByOutingId(it.id!!) }
+            .map {
+                it.comingAt = now
+                it.member.status = Status.COMING
+
+                Late(
+                    member = it.member,
+                    outing = it,
+                    comingAt = now,
+                    lateCount = lateRepository.countByMemberId(it.member.id!!) + 1
+                )
+            }
+
+        lateRepository.saveAll(lates)
+
+        log.info(
+            LogFormat.message(
+                domain = "SCHEDULER",
+                event = "late auto create completed",
+                "targetCount" to activeOutings.size,
+                "createdCount" to lates.size,
+                "durationMs" to System.currentTimeMillis() - start
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/late/job/LateAutoCreateJob.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/late/job/LateAutoCreateJob.kt
@@ -27,19 +27,33 @@ class LateAutoCreateJob(
         val now = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
 
         val activeOutings = outingRepository.findAllActiveWithOutingMember()
-        val lates = activeOutings
-            .filterNot { lateRepository.existsByOutingId(it.id!!) }
-            .map {
-                it.comingAt = now
-                it.member.status = Status.COMING
+        val outingIds = activeOutings.map { it.id!! }
+        val existingLateOutingIds = if (outingIds.isEmpty()) {
+            emptySet()
+        } else {
+            lateRepository.findAllOutingIdsIn(outingIds).toSet()
+        }
+        val targetOutings = activeOutings
+            .filterNot { existingLateOutingIds.contains(it.id!!) }
+        val memberIds = targetOutings.map { it.member.id!! }.distinct()
+        val lateCountByMemberId = if (memberIds.isEmpty()) {
+            emptyMap()
+        } else {
+            lateRepository.countByMemberIds(memberIds)
+                .associate { it.memberId to it.lateCount }
+        }
 
-                Late(
-                    member = it.member,
-                    outing = it,
-                    comingAt = now,
-                    lateCount = lateRepository.countByMemberId(it.member.id!!) + 1
-                )
-            }
+        val lates = targetOutings.map {
+            it.comingAt = now
+            it.member.status = Status.COMING
+
+            Late(
+                member = it.member,
+                outing = it,
+                comingAt = now,
+                lateCount = (lateCountByMemberId[it.member.id!!] ?: 0L) + 1
+            )
+        }
 
         lateRepository.saveAll(lates)
 

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/late/repository/LateRepository.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/late/repository/LateRepository.kt
@@ -39,5 +39,7 @@ interface LateRepository : JpaRepository<Late, Long> {
 
     fun countByMemberId(memberId: Long): Long
 
+    fun existsByOutingId(outingId: Long): Boolean
+
     fun deleteAllByMemberId(memberId: Long): Long
 }

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/late/repository/LateRepository.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/late/repository/LateRepository.kt
@@ -39,7 +39,29 @@ interface LateRepository : JpaRepository<Late, Long> {
 
     fun countByMemberId(memberId: Long): Long
 
-    fun existsByOutingId(outingId: Long): Boolean
+    @Query(
+        """
+        SELECT l.outing.id
+        FROM Late l
+        WHERE l.outing.id IN :outingIds
+        """
+    )
+    fun findAllOutingIdsIn(outingIds: List<Long>): List<Long>
+
+    @Query(
+        """
+        SELECT l.member.id AS memberId, COUNT(l) AS lateCount
+        FROM Late l
+        WHERE l.member.id IN :memberIds
+        GROUP BY l.member.id
+        """
+    )
+    fun countByMemberIds(memberIds: List<Long>): List<MemberLateCount>
 
     fun deleteAllByMemberId(memberId: Long): Long
+}
+
+interface MemberLateCount {
+    val memberId: Long
+    val lateCount: Long
 }

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/outing/repository/OutingRepository.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/outing/repository/OutingRepository.kt
@@ -26,6 +26,17 @@ interface OutingRepository : JpaRepository<Outing, Long> {
         select o from Outing o
         join fetch o.member m
         where o.comingAt is null
+          and m.status = com.example.team.haribo.goms.domain.common.enums.Status.OUTING
+        order by o.outingAt asc
+        """
+    )
+    fun findAllActiveWithOutingMember(): List<Outing>
+
+    @Query(
+        """
+        select o from Outing o
+        join fetch o.member m
+        where o.comingAt is null
           and lower(m.name) like lower(concat('%', :name, '%'))
         order by o.outingAt desc
         """

--- a/src/test/kotlin/com/example/team/haribo/goms/domain/late/job/LateAutoCreateJobTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/domain/late/job/LateAutoCreateJobTest.kt
@@ -1,0 +1,67 @@
+package com.example.team.haribo.goms.domain.late.job
+
+import com.example.team.haribo.goms.domain.common.enums.Status
+import com.example.team.haribo.goms.domain.late.entity.Late
+import com.example.team.haribo.goms.domain.late.repository.LateRepository
+import com.example.team.haribo.goms.domain.outing.repository.OutingRepository
+import com.example.team.haribo.goms.fixture.MemberFixture
+import com.example.team.haribo.goms.fixture.OutingFixture
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+
+class LateAutoCreateJobTest : DescribeSpec({
+
+    describe("LateAutoCreateJob") {
+
+        context("Given: OUTING 상태 활성 외출자가 존재한다") {
+            val member = MemberFixture.outing(id = 1L)
+            val outing = OutingFixture.active(member)
+            val lateSlot = slot<Iterable<Late>>()
+            val outingRepository = mockk<OutingRepository>()
+            val lateRepository = mockk<LateRepository>()
+            val job = LateAutoCreateJob(outingRepository, lateRepository)
+
+            every { outingRepository.findAllActiveWithOutingMember() } returns listOf(outing)
+            every { lateRepository.existsByOutingId(outing.id!!) } returns false
+            every { lateRepository.countByMemberId(member.id!!) } returns 2L
+            every { lateRepository.saveAll(capture(lateSlot)) } answers { firstArg<Iterable<Late>>().toList() }
+
+            it("When: 자동 지각 생성 시 Then: Late를 저장하고 외출 상태를 COMING으로 변경한다") {
+                job.createLatesForOutingMembers()
+
+                val late = lateSlot.captured.single()
+                late.member shouldBe member
+                late.outing shouldBe outing
+                late.lateCount shouldBe 3L
+                late.comingAt shouldNotBe null
+                outing.comingAt shouldNotBe null
+                member.status shouldBe Status.COMING
+            }
+        }
+
+        context("Given: 이미 같은 외출 건으로 지각이 생성되었다") {
+            val member = MemberFixture.outing(id = 2L)
+            val outing = OutingFixture.active(member)
+            val outingRepository = mockk<OutingRepository>()
+            val lateRepository = mockk<LateRepository>()
+            val job = LateAutoCreateJob(outingRepository, lateRepository)
+
+            every { outingRepository.findAllActiveWithOutingMember() } returns listOf(outing)
+            every { lateRepository.existsByOutingId(outing.id!!) } returns true
+            every { lateRepository.saveAll(emptyList<Late>()) } returns emptyList()
+
+            it("When: 자동 지각 생성 시 Then: 중복 저장하지 않고 상태를 변경하지 않는다") {
+                job.createLatesForOutingMembers()
+
+                member.status shouldBe Status.OUTING
+                outing.comingAt shouldBe null
+                verify(exactly = 0) { lateRepository.countByMemberId(any()) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/team/haribo/goms/domain/late/job/LateAutoCreateJobTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/domain/late/job/LateAutoCreateJobTest.kt
@@ -2,6 +2,7 @@ package com.example.team.haribo.goms.domain.late.job
 
 import com.example.team.haribo.goms.domain.common.enums.Status
 import com.example.team.haribo.goms.domain.late.entity.Late
+import com.example.team.haribo.goms.domain.late.repository.MemberLateCount
 import com.example.team.haribo.goms.domain.late.repository.LateRepository
 import com.example.team.haribo.goms.domain.outing.repository.OutingRepository
 import com.example.team.haribo.goms.fixture.MemberFixture
@@ -25,10 +26,13 @@ class LateAutoCreateJobTest : DescribeSpec({
             val outingRepository = mockk<OutingRepository>()
             val lateRepository = mockk<LateRepository>()
             val job = LateAutoCreateJob(outingRepository, lateRepository)
+            val memberLateCount = mockk<MemberLateCount>()
 
             every { outingRepository.findAllActiveWithOutingMember() } returns listOf(outing)
-            every { lateRepository.existsByOutingId(outing.id!!) } returns false
-            every { lateRepository.countByMemberId(member.id!!) } returns 2L
+            every { lateRepository.findAllOutingIdsIn(listOf(outing.id!!)) } returns emptyList()
+            every { lateRepository.countByMemberIds(listOf(member.id!!)) } returns listOf(memberLateCount)
+            every { memberLateCount.memberId } returns member.id!!
+            every { memberLateCount.lateCount } returns 2L
             every { lateRepository.saveAll(capture(lateSlot)) } answers { firstArg<Iterable<Late>>().toList() }
 
             it("When: 자동 지각 생성 시 Then: Late를 저장하고 외출 상태를 COMING으로 변경한다") {
@@ -52,7 +56,7 @@ class LateAutoCreateJobTest : DescribeSpec({
             val job = LateAutoCreateJob(outingRepository, lateRepository)
 
             every { outingRepository.findAllActiveWithOutingMember() } returns listOf(outing)
-            every { lateRepository.existsByOutingId(outing.id!!) } returns true
+            every { lateRepository.findAllOutingIdsIn(listOf(outing.id!!)) } returns listOf(outing.id!!)
             every { lateRepository.saveAll(emptyList<Late>()) } returns emptyList()
 
             it("When: 자동 지각 생성 시 Then: 중복 저장하지 않고 상태를 변경하지 않는다") {
@@ -61,6 +65,7 @@ class LateAutoCreateJobTest : DescribeSpec({
                 member.status shouldBe Status.OUTING
                 outing.comingAt shouldBe null
                 verify(exactly = 0) { lateRepository.countByMemberId(any()) }
+                verify(exactly = 0) { lateRepository.countByMemberIds(any()) }
             }
         }
     }


### PR DESCRIPTION
## 📃 작업내용
기존에 누락되어있던 지각 자동 생성 로직을 추가하였습니다.
## 🙋‍♂️ 참고사항
매주 월/수 오후 7시 30분에 `member.status = OUTING`인 사용자를 대상으로 지각을 생성하는 방식으로 구현했습니다.
## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?