### PR TITLE
외출 상태 전이 동시성 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     implementation 'io.netty:netty-tcnative-boringssl-static'
 
     // Test
+    testImplementation 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/member/repository/MemberRepository.kt
@@ -5,7 +5,9 @@ import com.example.team.haribo.goms.domain.common.enums.Gender
 import com.example.team.haribo.goms.domain.common.enums.Role
 import com.example.team.haribo.goms.domain.common.enums.Status
 import com.example.team.haribo.goms.domain.member.entity.Member
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -16,6 +18,15 @@ interface MemberRepository : JpaRepository<Member, Long> {
     fun findByEmail(email: String): Optional<Member>
 
     fun existsByEmail(email: String): Boolean
+
+    /**
+     * 외출/복귀 상태 전이(QR 외출·복귀, 학생회 강제 외출·복귀)처럼
+     * "조회 -> 상태 검증 -> 변경" 흐름이 동시에 들어올 수 있는 케이스 전용 조회.
+     * 커밋 전까지 동일 회원에 대한 다른 트랜잭션의 갱신을 막아 중복 Outing 생성을 방지한다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT m FROM Member m WHERE m.id = :id")
+    fun findByIdForUpdate(@Param("id") id: Long): Member?
 
     @Query(
         """

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/QrComingServiceImpl.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/QrComingServiceImpl.kt
@@ -27,7 +27,7 @@ class QrComingServiceImpl(
     override fun coming(request: QrToggleRequest): QrComingResponse {
         QrExpValidator.validate(request.exp)
 
-        val member = memberUtil.currentMember()
+        val member = memberUtil.currentMemberForUpdate()
         val memberId = member.id!!
         val beforeStatus = member.status
 

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/QrOutingServiceImpl.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/QrOutingServiceImpl.kt
@@ -29,7 +29,7 @@ class QrOutingServiceImpl(
     override fun outing(request: QrToggleRequest): QrOutingResponse {
         QrExpValidator.validate(request.exp)
 
-        val member = memberUtil.currentMember()
+        val member = memberUtil.currentMemberForUpdate()
         val beforeStatus = member.status
 
         log.info(

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/studentcouncil/service/impl/StudentCouncilForceInServiceImpl.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/studentcouncil/service/impl/StudentCouncilForceInServiceImpl.kt
@@ -32,7 +32,7 @@ class StudentCouncilForceInServiceImpl(
             )
         )
 
-        val member = memberRepository.findById(memberId).orElseThrow {
+        val member = memberRepository.findByIdForUpdate(memberId) ?: run {
             log.warn(
                 LogFormat.message(
                     domain = "STUDENT_COUNCIL",
@@ -41,7 +41,7 @@ class StudentCouncilForceInServiceImpl(
                     "reason" to "존재하지 않는 사용자"
                 )
             )
-            NotFoundMemberException()
+            throw NotFoundMemberException()
         }
 
         val active = outingRepository.findTopByMemberIdAndComingAtIsNullOrderByIdDesc(memberId)

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/studentcouncil/service/impl/StudentCouncilForceOutServiceImpl.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/studentcouncil/service/impl/StudentCouncilForceOutServiceImpl.kt
@@ -34,7 +34,7 @@ class StudentCouncilForceOutServiceImpl(
             )
         )
 
-        val member = memberRepository.findById(memberId).orElseThrow {
+        val member = memberRepository.findByIdForUpdate(memberId) ?: run {
             log.warn(
                 LogFormat.message(
                     domain = "STUDENT_COUNCIL",
@@ -43,7 +43,7 @@ class StudentCouncilForceOutServiceImpl(
                     "reason" to "존재하지 않는 사용자"
                 )
             )
-            NotFoundMemberException()
+            throw NotFoundMemberException()
         }
 
         if (member.status == Status.CANNOT_OUTING) {

--- a/src/main/kotlin/com/example/team/haribo/goms/global/util/MemberUtil.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/global/util/MemberUtil.kt
@@ -33,6 +33,15 @@ class MemberUtil(
         return memberRepository.findById(memberId).orElseThrow { NotFoundMemberException() }
     }
 
+    /**
+     * 상태 전이(외출/복귀 등)처럼 동시 요청에 대한 원자성이 필요한 로직에서 사용한다.
+     * 트랜잭션 커밋 전까지 해당 회원 row를 잠가 race condition을 막는다.
+     */
+    fun currentMemberForUpdate(): Member {
+        val memberId = currentMemberId()
+        return memberRepository.findByIdForUpdate(memberId) ?: throw NotFoundMemberException()
+    }
+
     private fun findMemberIdByEmail(email: String): Long {
         val member = memberRepository.findByEmail(email).orElseThrow { NotFoundMemberException() }
         return member.id!!

--- a/src/test/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/QrComingServiceImplTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/QrComingServiceImplTest.kt
@@ -27,7 +27,7 @@ class QrComingServiceImplTest : DescribeSpec({
         context("Given: OUTING 상태 멤버 + 유효 QR + 활성 Outing 존재") {
             val member = MemberFixture.outing()
             val activeOuting = OutingFixture.active(member)
-            every { memberUtil.currentMember() } returns member
+            every { memberUtil.currentMemberForUpdate() } returns member
             every { outingRepository.findTopByMemberIdAndComingAtIsNullOrderByIdDesc(member.id!!) } returns activeOuting
 
             it("When: 귀교 QR 스캔 시 Then: comingAt이 설정되고 상태가 COMING으로 변경된다") {
@@ -42,7 +42,7 @@ class QrComingServiceImplTest : DescribeSpec({
 
         context("Given: 활성 Outing 없음") {
             val member = MemberFixture.student()
-            every { memberUtil.currentMember() } returns member
+            every { memberUtil.currentMemberForUpdate() } returns member
             every { outingRepository.findTopByMemberIdAndComingAtIsNullOrderByIdDesc(any()) } returns null
 
             it("When: 귀교 QR 스캔 시 Then: NotOutingException이 발생한다") {

--- a/src/test/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/QrOutingConcurrencyTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/QrOutingConcurrencyTest.kt
@@ -1,0 +1,184 @@
+package com.example.team.haribo.goms.domain.outing.service.impl
+
+import com.example.team.haribo.goms.domain.common.enums.Department
+import com.example.team.haribo.goms.domain.common.enums.Gender
+import com.example.team.haribo.goms.domain.common.enums.Role
+import com.example.team.haribo.goms.domain.common.enums.Status
+import com.example.team.haribo.goms.domain.member.entity.Member
+import com.example.team.haribo.goms.domain.member.repository.MemberRepository
+import com.example.team.haribo.goms.domain.outing.dto.request.QrToggleRequest
+import com.example.team.haribo.goms.domain.outing.exception.AlreadyOutingException
+import com.example.team.haribo.goms.domain.outing.repository.OutingRepository
+import com.example.team.haribo.goms.domain.studentcouncil.service.impl.StudentCouncilForceOutServiceImpl
+import com.example.team.haribo.goms.global.util.MemberUtil
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.TestPropertySource
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * QrOutingServiceImpl.outing()의 "조회 -> 상태 검증 -> 저장" 흐름이
+ * 동시 요청에서도 활성 Outing을 하나만 생성하는지 실제 DB(H2)와 스레드로 재현·검증한다.
+ *
+ * @DataJpaTest는 기본적으로 테스트 메서드 전체를 하나의 트랜잭션으로 감싸고 롤백하지만,
+ * 그렇게 하면 스레드별로 실제 커밋되는 트랜잭션 경합을 재현할 수 없다.
+ * 그래서 클래스 레벨에 Propagation.NOT_SUPPORTED를 걸어 테스트 메서드 자체는 트랜잭션 밖에서 실행되게 하고,
+ * 서비스 메서드에 걸린 @Transactional이 스레드마다 독립적으로 커밋되도록 한다.
+ */
+@DataJpaTest
+@TestPropertySource(properties = ["spring.profiles.active="])
+@Import(MemberUtil::class, QrOutingServiceImpl::class, StudentCouncilForceOutServiceImpl::class)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class QrOutingConcurrencyTest @Autowired constructor(
+    private val memberRepository: MemberRepository,
+    private val outingRepository: OutingRepository,
+    private val qrOutingService: QrOutingServiceImpl,
+    private val studentCouncilForceOutService: StudentCouncilForceOutServiceImpl
+) {
+
+    @Test
+    fun `동시에 외출 요청을 보내도 활성 Outing은 하나만 생성된다`() {
+        val member = memberRepository.save(
+            Member(
+                email = "concurrency-test@gsm.hs.kr",
+                password = "encoded_password",
+                name = "동시성테스트",
+                grade = 1,
+                department = Department.SW,
+                gender = Gender.MALE,
+                role = Role.ROLE_STUDENT,
+                status = Status.COMING
+            )
+        )
+        val memberId = requireNotNull(member.id)
+
+        val threadCount = 8
+        val readyLatch = CountDownLatch(threadCount)
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(threadCount)
+        val successCount = AtomicInteger(0)
+        val alreadyOutingCount = AtomicInteger(0)
+        val unexpectedCount = AtomicInteger(0)
+        val executor = Executors.newFixedThreadPool(threadCount)
+
+        repeat(threadCount) {
+            executor.submit {
+                SecurityContextHolder.getContext().authentication =
+                    UsernamePasswordAuthenticationToken(memberId, null, emptyList())
+                readyLatch.countDown()
+                startLatch.await()
+                try {
+                    qrOutingService.outing(
+                        QrToggleRequest(uuid = "concurrency-uuid", exp = System.currentTimeMillis() + 60_000)
+                    )
+                    successCount.incrementAndGet()
+                } catch (e: AlreadyOutingException) {
+                    alreadyOutingCount.incrementAndGet()
+                } catch (e: Exception) {
+                    unexpectedCount.incrementAndGet()
+                } finally {
+                    SecurityContextHolder.clearContext()
+                    doneLatch.countDown()
+                }
+            }
+        }
+
+        readyLatch.await(5, TimeUnit.SECONDS)
+        startLatch.countDown()
+        doneLatch.await(15, TimeUnit.SECONDS)
+        executor.shutdown()
+
+        assertEquals(0, unexpectedCount.get(), "예상치 못한 예외는 발생하지 않아야 한다")
+        assertEquals(1, successCount.get(), "정확히 한 건만 외출 처리에 성공해야 한다")
+        assertEquals(threadCount - 1, alreadyOutingCount.get(), "나머지는 AlreadyOutingException으로 처리되어야 한다")
+
+        val activeOutingCount = outingRepository.findAllActiveWithMember()
+            .count { it.member.id == memberId }
+        assertEquals(1, activeOutingCount, "동시 요청 이후에도 활성 Outing row는 정확히 1건이어야 한다")
+    }
+
+    @Test
+    fun `학생의 QR 외출과 학생회의 강제 외출이 동시에 들어와도 활성 Outing은 하나만 생성된다`() {
+        val member = memberRepository.save(
+            Member(
+                email = "concurrency-cross-flow@gsm.hs.kr",
+                password = "encoded_password",
+                name = "교차흐름테스트",
+                grade = 1,
+                department = Department.SW,
+                gender = Gender.MALE,
+                role = Role.ROLE_STUDENT,
+                status = Status.COMING
+            )
+        )
+        val memberId = requireNotNull(member.id)
+
+        val readyLatch = CountDownLatch(2)
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(2)
+        val successCount = AtomicInteger(0)
+        val alreadyOutingCount = AtomicInteger(0)
+        val unexpectedCount = AtomicInteger(0)
+        val executor = Executors.newFixedThreadPool(2)
+
+        // Thread 1: 학생 본인의 QR 외출 요청
+        executor.submit {
+            SecurityContextHolder.getContext().authentication =
+                UsernamePasswordAuthenticationToken(memberId, null, emptyList())
+            readyLatch.countDown()
+            startLatch.await()
+            try {
+                qrOutingService.outing(
+                    QrToggleRequest(uuid = "cross-flow-uuid", exp = System.currentTimeMillis() + 60_000)
+                )
+                successCount.incrementAndGet()
+            } catch (e: AlreadyOutingException) {
+                alreadyOutingCount.incrementAndGet()
+            } catch (e: Exception) {
+                unexpectedCount.incrementAndGet()
+            } finally {
+                SecurityContextHolder.clearContext()
+                doneLatch.countDown()
+            }
+        }
+
+        // Thread 2: 같은 학생에 대한 학생회의 강제 외출 요청 (SecurityContext 불필요)
+        executor.submit {
+            readyLatch.countDown()
+            startLatch.await()
+            try {
+                studentCouncilForceOutService.out(memberId)
+                successCount.incrementAndGet()
+            } catch (e: AlreadyOutingException) {
+                alreadyOutingCount.incrementAndGet()
+            } catch (e: Exception) {
+                unexpectedCount.incrementAndGet()
+            } finally {
+                doneLatch.countDown()
+            }
+        }
+
+        readyLatch.await(5, TimeUnit.SECONDS)
+        startLatch.countDown()
+        doneLatch.await(15, TimeUnit.SECONDS)
+        executor.shutdown()
+
+        assertEquals(0, unexpectedCount.get(), "예상치 못한 예외는 발생하지 않아야 한다")
+        assertEquals(1, successCount.get(), "두 흐름 중 정확히 하나만 성공해야 한다")
+        assertEquals(1, alreadyOutingCount.get(), "나머지 하나는 AlreadyOutingException으로 처리되어야 한다")
+
+        val activeOutingCount = outingRepository.findAllActiveWithMember()
+            .count { it.member.id == memberId }
+        assertEquals(1, activeOutingCount, "서로 다른 서비스 진입점이어도 활성 Outing row는 정확히 1건이어야 한다")
+    }
+}

--- a/src/test/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/QrOutingServiceImplTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/domain/outing/service/impl/QrOutingServiceImplTest.kt
@@ -27,7 +27,7 @@ class QrOutingServiceImplTest : DescribeSpec({
 
         context("Given: COMING 상태 멤버 + 유효한 QR") {
             val member = MemberFixture.student(status = Status.COMING)
-            every { memberUtil.currentMember() } returns member
+            every { memberUtil.currentMemberForUpdate() } returns member
             every { outingRepository.save(any()) } answers {
                 firstArg<com.example.team.haribo.goms.domain.outing.entity.Outing>().also { it.id = 10L }
             }
@@ -42,7 +42,7 @@ class QrOutingServiceImplTest : DescribeSpec({
         }
 
         context("Given: CANNOT_OUTING 상태 멤버") {
-            every { memberUtil.currentMember() } returns MemberFixture.cannotOuting()
+            every { memberUtil.currentMemberForUpdate() } returns MemberFixture.cannotOuting()
 
             it("When: 외출 QR 스캔 시 Then: CannotOutingException이 발생한다") {
                 shouldThrow<CannotOutingException> {
@@ -52,7 +52,7 @@ class QrOutingServiceImplTest : DescribeSpec({
         }
 
         context("Given: 이미 OUTING 상태 멤버") {
-            every { memberUtil.currentMember() } returns MemberFixture.outing()
+            every { memberUtil.currentMemberForUpdate() } returns MemberFixture.outing()
 
             it("When: 외출 QR 스캔 시 Then: AlreadyOutingException이 발생한다") {
                 shouldThrow<AlreadyOutingException> {

--- a/src/test/kotlin/com/example/team/haribo/goms/domain/studentcouncil/service/impl/StudentCouncilForceInServiceImplTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/domain/studentcouncil/service/impl/StudentCouncilForceInServiceImplTest.kt
@@ -14,7 +14,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
-import java.util.Optional
 
 class StudentCouncilForceInServiceImplTest : DescribeSpec({
 
@@ -27,7 +26,7 @@ class StudentCouncilForceInServiceImplTest : DescribeSpec({
         context("Given: OUTING 상태 멤버 + 활성 Outing 있음") {
             val member = MemberFixture.outing(id = 1L)
             val activeOuting = OutingFixture.active(member)
-            every { memberRepository.findById(1L) } returns Optional.of(member)
+            every { memberRepository.findByIdForUpdate(1L) } returns member
             every { outingRepository.findTopByMemberIdAndComingAtIsNullOrderByIdDesc(1L) } returns activeOuting
 
             it("When: 강제 귀교 시 Then: comingAt이 설정되고 상태가 COMING으로 변경된다") {
@@ -41,7 +40,7 @@ class StudentCouncilForceInServiceImplTest : DescribeSpec({
         }
 
         context("Given: 존재하지 않는 memberId") {
-            every { memberRepository.findById(999L) } returns Optional.empty()
+            every { memberRepository.findByIdForUpdate(999L) } returns null
 
             it("When: 강제 귀교 시 Then: NotFoundMemberException이 발생한다") {
                 shouldThrow<NotFoundMemberException> {
@@ -52,7 +51,7 @@ class StudentCouncilForceInServiceImplTest : DescribeSpec({
 
         context("Given: 활성 Outing 없음") {
             val member = MemberFixture.student(id = 2L)
-            every { memberRepository.findById(2L) } returns Optional.of(member)
+            every { memberRepository.findByIdForUpdate(2L) } returns member
             every { outingRepository.findTopByMemberIdAndComingAtIsNullOrderByIdDesc(2L) } returns null
 
             it("When: 강제 귀교 시 Then: NotOutingException이 발생한다") {

--- a/src/test/kotlin/com/example/team/haribo/goms/domain/studentcouncil/service/impl/StudentCouncilForceOutServiceImplTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/domain/studentcouncil/service/impl/StudentCouncilForceOutServiceImplTest.kt
@@ -14,7 +14,6 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.Optional
 
 class StudentCouncilForceOutServiceImplTest : DescribeSpec({
 
@@ -26,7 +25,7 @@ class StudentCouncilForceOutServiceImplTest : DescribeSpec({
 
         context("Given: COMING 상태 멤버") {
             val member = MemberFixture.student(id = 1L, status = Status.COMING)
-            every { memberRepository.findById(1L) } returns Optional.of(member)
+            every { memberRepository.findByIdForUpdate(1L) } returns member
             every { outingRepository.save(any()) } answers {
                 firstArg<com.example.team.haribo.goms.domain.outing.entity.Outing>().also { it.id = 10L }
             }
@@ -41,7 +40,7 @@ class StudentCouncilForceOutServiceImplTest : DescribeSpec({
         }
 
         context("Given: 존재하지 않는 memberId") {
-            every { memberRepository.findById(999L) } returns Optional.empty()
+            every { memberRepository.findByIdForUpdate(999L) } returns null
 
             it("When: 강제 외출 시 Then: NotFoundMemberException이 발생한다") {
                 shouldThrow<NotFoundMemberException> {
@@ -51,7 +50,7 @@ class StudentCouncilForceOutServiceImplTest : DescribeSpec({
         }
 
         context("Given: CANNOT_OUTING 상태 멤버") {
-            every { memberRepository.findById(3L) } returns Optional.of(MemberFixture.cannotOuting(id = 3L))
+            every { memberRepository.findByIdForUpdate(3L) } returns MemberFixture.cannotOuting(id = 3L)
 
             it("When: 강제 외출 시 Then: CannotOutingException이 발생한다") {
                 shouldThrow<CannotOutingException> {
@@ -61,7 +60,7 @@ class StudentCouncilForceOutServiceImplTest : DescribeSpec({
         }
 
         context("Given: 이미 OUTING 상태 멤버") {
-            every { memberRepository.findById(4L) } returns Optional.of(MemberFixture.outing(id = 4L))
+            every { memberRepository.findByIdForUpdate(4L) } returns MemberFixture.outing(id = 4L)
 
             it("When: 강제 외출 시 Then: AlreadyOutingException이 발생한다") {
                 shouldThrow<AlreadyOutingException> {


### PR DESCRIPTION
## 📃 작업내용
QR 외출/복귀, 학생회 강제 외출/복귀 로직에서 "회원 조회 → 상태 검증 → 저장" 흐름이 잠금 없이 처리되어, 동시 요청이 들어오면 같은 회원에게 활성 Outing이 중복 생성될 수 있는 race condition을 수정했습니다.

## 🙋‍♂️ 참고사항
- `MemberRepository`에 `PESSIMISTIC_WRITE` 락을 거는 `findByIdForUpdate`를 추가하고, QR 외출/복귀·학생회 강제 외출/복귀 4개 로직에 적용했습니다.
- 실제 DB(H2)와 멀티스레드로 동시 요청을 재현하는 테스트를 추가했습니다. 락 적용 전 코드로 먼저 테스트가 실패(중복 처리 성공)하는 것을 확인한 뒤, 락 적용 후 통과하는 것까지 확인했습니다.
- 학생 본인의 QR 외출 요청과 학생회의 강제 외출 요청이 같은 회원에 대해 동시에 들어오는 케이스(서로 다른 서비스 진입점 간 경합)도 함께 재현·검증했습니다.
- 기존 API 스펙(엔드포인트, 요청/응답 필드, 예외 종류) 변경 없이 내부 조회 로직만 수정했습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
