### PR TITLE
외출 활성 조회 풀스캔 방지 인덱스 추가

### DIFF
--- a/src/main/kotlin/com/example/team/haribo/goms/domain/outing/entity/Outing.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/outing/entity/Outing.kt
@@ -5,7 +5,16 @@ import jakarta.persistence.*
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "outing")
+@Table(
+    name = "outing",
+    indexes = [
+        // findAllActiveWithMember / countActive / searchActiveWithMemberByName 등
+        // "WHERE coming_at IS NULL" 로 활성 외출만 조회하는 쿼리가 outing 테이블 전체를
+        // Full Scan 하지 않도록 하기 위한 인덱스. outing row는 정리 배치 없이 계속 누적되므로
+        // 데이터가 쌓일수록 이 인덱스의 효과가 커진다.
+        Index(name = "idx_outing_coming_at", columnList = "coming_at")
+    ]
+)
 class Outing(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)


### PR DESCRIPTION
## 📃 작업내용
`outing` 테이블에서 "현재 외출 중"인 row(`coming_at IS NULL`)만 조회하는 쿼리들(`findAllActiveWithMember`, `countActive`, `searchActiveWithMemberByName`, 학생회 외출 학생 목록·카운트 API에서 사용)이 `coming_at`에 인덱스가 없어 테이블 전체를 스캔하고 있어서 인덱스를 추가했습니다.

## 🙋‍♂️ 참고사항
- `outing` row는 정리 배치 없이 계속 누적되는 구조라, 데이터가 쌓일수록 위 쿼리들의 비용이 커지는 구조였습니다.
- Docker로 MariaDB 11(운영과 동일 엔진)을 띄우고, 실제 운영 데이터가 아닌 합성 데이터(멤버 300명, outing 약 21만 건 · 활성 30건)로 인덱스 추가 전/후를 측정했습니다.
  - `findAllActiveWithMember` 조회 시 스캔하는 행 수: **약 210,000행 → 약 30행**로 EXPLAIN 상 확인 (`type: ALL` 기반 nested loop → `idx_outing_coming_at`을 통한 `type: ref`)
  - 같은 쿼리 20회 반복 실행 평균 응답시간: **약 210ms → 약 0.14ms**
  - `countActive` 쿼리 20회 반복 실행 평균 응답시간: **약 20.6ms → 약 0.05ms**
  - (측정용 컨테이너/스크립트는 로컬에서만 사용했고 저장소에는 포함하지 않았습니다. 필요하시면 공유드릴 수 있습니다.)
- 순수 인덱스 추가라 기존 데이터·쿼리·API 응답에는 영향이 없습니다. `ddl-auto: update`라 배포 시 별도 마이그레이션 스크립트 없이 자동 반영됩니다.
- 전체 테스트(`./gradlew test`) 통과 확인했습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
