### PR TITLE
장소 동기화 외부 API 호출 트랜잭션 범위 분리

### DIFF
--- a/src/main/kotlin/com/example/team/haribo/goms/domain/place/service/PlaceSyncWriter.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/place/service/PlaceSyncWriter.kt
@@ -1,0 +1,82 @@
+package com.example.team.haribo.goms.domain.place.service
+
+import com.example.team.haribo.goms.domain.place.dto.response.KakaoPlaceDocument
+import com.example.team.haribo.goms.domain.place.entity.Place
+import com.example.team.haribo.goms.domain.place.repository.PlaceRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+/**
+ * PlaceSyncServiceImpl.sync()에서 카카오 API 호출(외부 I/O) 단계와 DB 반영 단계를 분리하기 위한 컴포넌트.
+ * 최대 수백~천 회에 달하는 외부 API 호출은 트랜잭션 밖에서 끝내고, DB 반영만 이 클래스의
+ * 짧은 트랜잭션 안에서 처리해 커넥션 점유 시간을 줄인다.
+ */
+@Component
+class PlaceSyncWriter(
+    private val placeRepository: PlaceRepository
+) {
+
+    @Transactional
+    fun write(documents: List<KakaoPlaceDocument>, syncStartedAt: LocalDateTime): PlaceSyncWriteResult {
+        var createdCount = 0
+        var updatedCount = 0
+
+        documents.forEach { document ->
+            val existing = placeRepository.findByExternalPlaceId(document.id).orElse(null)
+
+            if (existing == null) {
+                placeRepository.save(
+                    Place(
+                        externalPlaceId = document.id,
+                        placeName = document.place_name,
+                        address = document.address_name,
+                        roadAddress = document.road_address_name,
+                        latitude = document.y.toDouble(),
+                        longitude = document.x.toDouble(),
+                        categoryGroupCode = document.category_group_code,
+                        categoryGroupName = document.category_group_name,
+                        categoryName = document.category_name,
+                        phone = document.phone,
+                        placeUrl = document.place_url,
+                        isActive = true,
+                        lastSyncedAt = syncStartedAt,
+                        createdAt = syncStartedAt,
+                        updatedAt = syncStartedAt
+                    )
+                )
+                createdCount++
+            } else {
+                existing.sync(
+                    placeName = document.place_name,
+                    address = document.address_name,
+                    roadAddress = document.road_address_name,
+                    latitude = document.y.toDouble(),
+                    longitude = document.x.toDouble(),
+                    categoryGroupCode = document.category_group_code,
+                    categoryGroupName = document.category_group_name,
+                    categoryName = document.category_name,
+                    phone = document.phone,
+                    placeUrl = document.place_url,
+                    syncedAt = syncStartedAt
+                )
+                updatedCount++
+            }
+        }
+
+        val placesToDeactivate = placeRepository.findAllByLastSyncedAtBeforeAndIsActiveTrue(syncStartedAt)
+        placesToDeactivate.forEach { it.deactivate(syncStartedAt) }
+
+        return PlaceSyncWriteResult(
+            createdCount = createdCount,
+            updatedCount = updatedCount,
+            deactivatedCount = placesToDeactivate.size
+        )
+    }
+}
+
+data class PlaceSyncWriteResult(
+    val createdCount: Int,
+    val updatedCount: Int,
+    val deactivatedCount: Int
+)

--- a/src/main/kotlin/com/example/team/haribo/goms/domain/place/service/impl/PlaceSyncServiceImpl.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/domain/place/service/impl/PlaceSyncServiceImpl.kt
@@ -4,9 +4,8 @@ import com.example.team.haribo.goms.domain.common.enums.PlaceSyncCategory
 import com.example.team.haribo.goms.domain.place.client.KakaoPlaceClient
 import com.example.team.haribo.goms.domain.place.dto.response.KakaoPlaceDocument
 import com.example.team.haribo.goms.domain.place.dto.response.PlaceSyncResult
-import com.example.team.haribo.goms.domain.place.entity.Place
-import com.example.team.haribo.goms.domain.place.repository.PlaceRepository
 import com.example.team.haribo.goms.domain.place.service.PlaceSyncService
+import com.example.team.haribo.goms.domain.place.service.PlaceSyncWriter
 import com.example.team.haribo.goms.domain.place.util.PlaceDistanceCalculator
 import com.example.team.haribo.goms.domain.place.util.PlaceSearchPointGenerator
 import com.example.team.haribo.goms.domain.place.util.PlaceSyncFilter
@@ -14,13 +13,12 @@ import com.example.team.haribo.goms.domain.place.util.SearchPoint
 import com.example.team.haribo.goms.global.log.LogFormat
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 @Service
 class PlaceSyncServiceImpl(
     private val kakaoPlaceClient: KakaoPlaceClient,
-    private val placeRepository: PlaceRepository,
+    private val placeSyncWriter: PlaceSyncWriter,
     private val placeSyncFilter: PlaceSyncFilter,
     private val placeSearchPointGenerator: PlaceSearchPointGenerator,
     private val placeDistanceCalculator: PlaceDistanceCalculator
@@ -36,7 +34,12 @@ class PlaceSyncServiceImpl(
     private val pageSize = 15
     private val maxPage = 3
 
-    @Transactional
+    /**
+     * 카카오 API 호출(최대 수백~천 회에 달하는 외부 I/O)과 DB 반영을 한 트랜잭션 안에서 처리하면
+     * 외부 API 응답을 기다리는 동안 DB 커넥션을 계속 점유하게 된다.
+     * 그래서 이 메서드 자체는 트랜잭션을 걸지 않고, 외부 호출(fetchAllDocuments)을 먼저 끝낸 뒤
+     * DB 반영만 PlaceSyncWriter의 짧은 트랜잭션 안에서 처리하도록 분리했다.
+     */
     override fun sync(): PlaceSyncResult {
         val syncStartedAt = LocalDateTime.now()
         val searchPoints = placeSearchPointGenerator.generate(
@@ -48,53 +51,7 @@ class PlaceSyncServiceImpl(
 
         val fetchResult = fetchAllDocuments(searchPoints)
 
-        var createdCount = 0
-        var updatedCount = 0
-
-        fetchResult.documents.forEach { document ->
-            val existing = placeRepository.findByExternalPlaceId(document.id).orElse(null)
-
-            if (existing == null) {
-                placeRepository.save(
-                    Place(
-                        externalPlaceId = document.id,
-                        placeName = document.place_name,
-                        address = document.address_name,
-                        roadAddress = document.road_address_name,
-                        latitude = document.y.toDouble(),
-                        longitude = document.x.toDouble(),
-                        categoryGroupCode = document.category_group_code,
-                        categoryGroupName = document.category_group_name,
-                        categoryName = document.category_name,
-                        phone = document.phone,
-                        placeUrl = document.place_url,
-                        isActive = true,
-                        lastSyncedAt = syncStartedAt,
-                        createdAt = syncStartedAt,
-                        updatedAt = syncStartedAt
-                    )
-                )
-                createdCount++
-            } else {
-                existing.sync(
-                    placeName = document.place_name,
-                    address = document.address_name,
-                    roadAddress = document.road_address_name,
-                    latitude = document.y.toDouble(),
-                    longitude = document.x.toDouble(),
-                    categoryGroupCode = document.category_group_code,
-                    categoryGroupName = document.category_group_name,
-                    categoryName = document.category_name,
-                    phone = document.phone,
-                    placeUrl = document.place_url,
-                    syncedAt = syncStartedAt
-                )
-                updatedCount++
-            }
-        }
-
-        val placesToDeactivate = placeRepository.findAllByLastSyncedAtBeforeAndIsActiveTrue(syncStartedAt)
-        placesToDeactivate.forEach { it.deactivate(syncStartedAt) }
+        val writeResult = placeSyncWriter.write(fetchResult.documents, syncStartedAt)
 
         log.info(
             LogFormat.message(
@@ -103,16 +60,16 @@ class PlaceSyncServiceImpl(
                 "searchPointCount" to searchPoints.size,
                 "rawCollectedCount" to fetchResult.rawCollectedCount,
                 "totalFetchedCount" to fetchResult.documents.size,
-                "createdCount" to createdCount,
-                "updatedCount" to updatedCount,
-                "deactivatedCount" to placesToDeactivate.size
+                "createdCount" to writeResult.createdCount,
+                "updatedCount" to writeResult.updatedCount,
+                "deactivatedCount" to writeResult.deactivatedCount
             )
         )
 
         return PlaceSyncResult(
-            createdCount = createdCount,
-            updatedCount = updatedCount,
-            deactivatedCount = placesToDeactivate.size,
+            createdCount = writeResult.createdCount,
+            updatedCount = writeResult.updatedCount,
+            deactivatedCount = writeResult.deactivatedCount,
             totalFetchedCount = fetchResult.documents.size,
             searchPointCount = searchPoints.size,
             rawCollectedCount = fetchResult.rawCollectedCount

--- a/src/test/kotlin/com/example/team/haribo/goms/domain/place/service/PlaceSyncWriterTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/domain/place/service/PlaceSyncWriterTest.kt
@@ -1,0 +1,107 @@
+package com.example.team.haribo.goms.domain.place.service
+
+import com.example.team.haribo.goms.domain.place.dto.response.KakaoPlaceDocument
+import com.example.team.haribo.goms.domain.place.entity.Place
+import com.example.team.haribo.goms.domain.place.repository.PlaceRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDateTime
+import java.util.Optional
+
+class PlaceSyncWriterTest : DescribeSpec({
+
+    val placeRepository = mockk<PlaceRepository>()
+    val writer = PlaceSyncWriter(placeRepository)
+
+    val syncStartedAt = LocalDateTime.now()
+
+    val document = KakaoPlaceDocument(
+        id = "kakao-place-1",
+        place_name = "테스트 식당",
+        category_name = "음식점 > 중식",
+        category_group_code = "FD6",
+        category_group_name = "음식점",
+        phone = "010-1234-5678",
+        address_name = "광주 광산구 테스트로 1",
+        road_address_name = "광주 광산구 테스트로 1",
+        x = "126.8008",
+        y = "35.1428",
+        place_url = "https://place.map.kakao.com/1"
+    )
+
+    describe("PlaceSyncWriter") {
+
+        context("Given: 처음 수집된 장소") {
+            every { placeRepository.findByExternalPlaceId(document.id) } returns Optional.empty()
+            every { placeRepository.save(any()) } answers { firstArg() }
+            every { placeRepository.findAllByLastSyncedAtBeforeAndIsActiveTrue(any()) } returns emptyList()
+
+            it("When: write 호출 시 Then: 새 장소가 생성된다") {
+                val result = writer.write(listOf(document), syncStartedAt)
+
+                result.createdCount shouldBe 1
+                result.updatedCount shouldBe 0
+                result.deactivatedCount shouldBe 0
+                verify(exactly = 1) { placeRepository.save(any()) }
+            }
+        }
+
+        context("Given: 이미 존재하는 장소 + 정리 대상(stale) 장소") {
+            val existing = Place(
+                id = 1L,
+                externalPlaceId = document.id,
+                placeName = "기존 장소명",
+                address = "기존 주소",
+                roadAddress = null,
+                latitude = 35.0,
+                longitude = 126.0,
+                categoryGroupCode = "FD6",
+                categoryGroupName = "음식점",
+                categoryName = "기존 카테고리",
+                phone = null,
+                placeUrl = null,
+                isActive = true,
+                lastSyncedAt = LocalDateTime.now().minusDays(1),
+                createdAt = LocalDateTime.now().minusDays(10),
+                updatedAt = LocalDateTime.now().minusDays(1)
+            )
+
+            val stale = Place(
+                id = 2L,
+                externalPlaceId = "stale-place",
+                placeName = "오래된 장소",
+                address = "광주",
+                roadAddress = null,
+                latitude = 35.1,
+                longitude = 126.1,
+                categoryGroupCode = "FD6",
+                categoryGroupName = "음식점",
+                categoryName = "한식",
+                phone = null,
+                placeUrl = null,
+                isActive = true,
+                lastSyncedAt = LocalDateTime.now().minusDays(30),
+                createdAt = LocalDateTime.now().minusDays(50),
+                updatedAt = LocalDateTime.now().minusDays(30)
+            )
+
+            every { placeRepository.findByExternalPlaceId(document.id) } returns Optional.of(existing)
+            every { placeRepository.findAllByLastSyncedAtBeforeAndIsActiveTrue(any()) } returns listOf(stale)
+
+            it("When: write 호출 시 Then: 기존 장소는 갱신되고 stale 장소는 비활성화된다") {
+                val result = writer.write(listOf(document), syncStartedAt)
+
+                result.createdCount shouldBe 0
+                result.updatedCount shouldBe 1
+                result.deactivatedCount shouldBe 1
+
+                existing.placeName shouldBe "테스트 식당"
+                existing.address shouldBe "광주 광산구 테스트로 1"
+                stale.isActive shouldBe false
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/team/haribo/goms/domain/place/service/impl/PlaceSyncServiceImplTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/domain/place/service/impl/PlaceSyncServiceImplTest.kt
@@ -4,8 +4,8 @@ import com.example.team.haribo.goms.domain.place.client.KakaoPlaceClient
 import com.example.team.haribo.goms.domain.place.dto.response.KakaoPlaceDocument
 import com.example.team.haribo.goms.domain.place.dto.response.KakaoPlaceMeta
 import com.example.team.haribo.goms.domain.place.dto.response.KakaoPlaceSearchResponse
-import com.example.team.haribo.goms.domain.place.entity.Place
-import com.example.team.haribo.goms.domain.place.repository.PlaceRepository
+import com.example.team.haribo.goms.domain.place.service.PlaceSyncWriteResult
+import com.example.team.haribo.goms.domain.place.service.PlaceSyncWriter
 import com.example.team.haribo.goms.domain.place.util.PlaceDistanceCalculator
 import com.example.team.haribo.goms.domain.place.util.PlaceSearchPointGenerator
 import com.example.team.haribo.goms.domain.place.util.PlaceSyncFilter
@@ -14,21 +14,20 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
-import java.time.LocalDateTime
-import java.util.Optional
 
 class PlaceSyncServiceImplTest : DescribeSpec({
 
     val kakaoPlaceClient = mockk<KakaoPlaceClient>()
-    val placeRepository = mockk<PlaceRepository>()
+    val placeSyncWriter = mockk<PlaceSyncWriter>()
     val placeSyncFilter = mockk<PlaceSyncFilter>()
     val placeSearchPointGenerator = mockk<PlaceSearchPointGenerator>()
     val placeDistanceCalculator = mockk<PlaceDistanceCalculator>()
 
     val service = PlaceSyncServiceImpl(
         kakaoPlaceClient,
-        placeRepository,
+        placeSyncWriter,
         placeSyncFilter,
         placeSearchPointGenerator,
         placeDistanceCalculator
@@ -97,11 +96,11 @@ class PlaceSyncServiceImplTest : DescribeSpec({
                 )
             } returns true
 
-            every { placeRepository.findByExternalPlaceId(document.id) } returns Optional.empty()
-            every { placeRepository.save(any()) } answers { firstArg() }
-            every { placeRepository.findAllByLastSyncedAtBeforeAndIsActiveTrue(any()) } returns emptyList()
+            val documentsSlot = slot<List<KakaoPlaceDocument>>()
+            every { placeSyncWriter.write(capture(documentsSlot), any()) } returns
+                PlaceSyncWriteResult(createdCount = 1, updatedCount = 0, deactivatedCount = 0)
 
-            it("When: 장소 동기화 시 Then: 새 장소가 생성된다") {
+            it("When: 장소 동기화 시 Then: 수집된 문서로 DB 반영을 위임하고 결과를 집계한다") {
                 val result = service.sync()
 
                 result.createdCount shouldBe 1
@@ -111,49 +110,12 @@ class PlaceSyncServiceImplTest : DescribeSpec({
                 result.searchPointCount shouldBe 1
                 result.rawCollectedCount shouldBe 8
 
-                verify(exactly = 1) { placeRepository.save(any()) }
+                documentsSlot.captured shouldBe listOf(document)
+                verify(exactly = 1) { placeSyncWriter.write(any(), any()) }
             }
         }
 
-        context("Given: 기존 장소 갱신과 비활성화 대상이 있음") {
-            val existing = Place(
-                id = 1L,
-                externalPlaceId = document.id,
-                placeName = "기존 장소명",
-                address = "기존 주소",
-                roadAddress = null,
-                latitude = 35.0,
-                longitude = 126.0,
-                categoryGroupCode = "FD6",
-                categoryGroupName = "음식점",
-                categoryName = "기존 카테고리",
-                phone = null,
-                placeUrl = null,
-                isActive = true,
-                lastSyncedAt = LocalDateTime.now().minusDays(1),
-                createdAt = LocalDateTime.now().minusDays(10),
-                updatedAt = LocalDateTime.now().minusDays(1)
-            )
-
-            val stale = Place(
-                id = 2L,
-                externalPlaceId = "stale-place",
-                placeName = "오래된 장소",
-                address = "광주",
-                roadAddress = null,
-                latitude = 35.1,
-                longitude = 126.1,
-                categoryGroupCode = "FD6",
-                categoryGroupName = "음식점",
-                categoryName = "한식",
-                phone = null,
-                placeUrl = null,
-                isActive = true,
-                lastSyncedAt = LocalDateTime.now().minusDays(30),
-                createdAt = LocalDateTime.now().minusDays(50),
-                updatedAt = LocalDateTime.now().minusDays(30)
-            )
-
+        context("Given: 필터/반경 조건에 걸려 제외되는 문서가 있음") {
             every {
                 placeSearchPointGenerator.generate(
                     centerLatitude = any(),
@@ -174,31 +136,18 @@ class PlaceSyncServiceImplTest : DescribeSpec({
                 )
             } returns response
 
-            every { placeSyncFilter.isAllowed(document) } returns true
-            every {
-                placeDistanceCalculator.isWithinRadius(
-                    originLatitude = any(),
-                    originLongitude = any(),
-                    targetLatitude = document.y.toDouble(),
-                    targetLongitude = document.x.toDouble(),
-                    radiusMeter = any()
-                )
-            } returns true
+            every { placeSyncFilter.isAllowed(document) } returns false
 
-            every { placeRepository.findByExternalPlaceId(document.id) } returns Optional.of(existing)
-            every { placeRepository.findAllByLastSyncedAtBeforeAndIsActiveTrue(any()) } returns listOf(stale)
+            val documentsSlot = slot<List<KakaoPlaceDocument>>()
+            every { placeSyncWriter.write(capture(documentsSlot), any()) } returns
+                PlaceSyncWriteResult(createdCount = 0, updatedCount = 0, deactivatedCount = 0)
 
-            it("When: 장소 동기화 시 Then: 기존 장소가 갱신되고 오래된 장소는 비활성화된다") {
+            it("When: 장소 동기화 시 Then: 제외된 문서는 PlaceSyncWriter로 전달되지 않는다") {
                 val result = service.sync()
 
-                result.createdCount shouldBe 0
-                result.updatedCount shouldBe 1
-                result.deactivatedCount shouldBe 1
-                result.totalFetchedCount shouldBe 1
-
-                existing.placeName shouldBe "테스트 식당"
-                existing.address shouldBe "광주 광산구 테스트로 1"
-                stale.isActive shouldBe false
+                result.totalFetchedCount shouldBe 0
+                result.rawCollectedCount shouldBe 8
+                documentsSlot.captured shouldBe emptyList()
             }
         }
     }

--- a/src/test/kotlin/com/example/team/haribo/goms/domain/place/service/impl/PlaceSyncTransactionScopeTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/domain/place/service/impl/PlaceSyncTransactionScopeTest.kt
@@ -1,0 +1,107 @@
+package com.example.team.haribo.goms.domain.place.service.impl
+
+import com.example.team.haribo.goms.domain.place.client.KakaoPlaceClient
+import com.example.team.haribo.goms.domain.place.dto.response.KakaoPlaceMeta
+import com.example.team.haribo.goms.domain.place.dto.response.KakaoPlaceSearchResponse
+import com.example.team.haribo.goms.domain.place.entity.Place
+import com.example.team.haribo.goms.domain.place.repository.PlaceRepository
+import com.example.team.haribo.goms.domain.place.service.PlaceSyncWriter
+import com.example.team.haribo.goms.domain.place.util.PlaceDistanceCalculator
+import com.example.team.haribo.goms.domain.place.util.PlaceSearchPointGenerator
+import com.example.team.haribo.goms.domain.place.util.PlaceSyncFilter
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.TestPropertySource
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import java.time.LocalDateTime
+
+/**
+ * PlaceSyncServiceImpl.sync()가 카카오 API 호출(외부 I/O)을 트랜잭션 밖에서 수행하고,
+ * DB 반영(PlaceSyncWriter)만 짧은 트랜잭션 안에서 커밋하는지 검증한다.
+ *
+ * @DataJpaTest 기본 롤백 트랜잭션을 쓰면 sync() 내부에서 커밋되는 PlaceSyncWriter의
+ * 트랜잭션을 관찰할 수 없으므로, 클래스 레벨에 Propagation.NOT_SUPPORTED를 걸어
+ * 테스트 메서드 자체는 트랜잭션 밖에서 실행되게 한다.
+ */
+@DataJpaTest
+@TestPropertySource(properties = ["spring.profiles.active="])
+@Import(PlaceSyncWriter::class)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class PlaceSyncTransactionScopeTest @Autowired constructor(
+    private val placeRepository: PlaceRepository,
+    private val placeSyncWriter: PlaceSyncWriter
+) {
+
+    @Test
+    fun `외부 API 호출 중에는 트랜잭션이 열려있지 않고, DB 반영은 정상적으로 커밋된다`() {
+        val stalePlace = placeRepository.save(
+            Place(
+                externalPlaceId = "stale-place",
+                placeName = "정리 대상 장소",
+                address = "광주",
+                roadAddress = null,
+                latitude = 35.1,
+                longitude = 126.1,
+                categoryGroupCode = "FD6",
+                categoryGroupName = "음식점",
+                categoryName = "한식",
+                phone = null,
+                placeUrl = null,
+                isActive = true,
+                lastSyncedAt = LocalDateTime.now().minusDays(30),
+                createdAt = LocalDateTime.now().minusDays(50),
+                updatedAt = LocalDateTime.now().minusDays(30)
+            )
+        )
+
+        var callCount = 0
+        val transactionActiveDuringFetch = mutableListOf<Boolean>()
+        val kakaoPlaceClient = mockk<KakaoPlaceClient>()
+        every {
+            kakaoPlaceClient.searchByCategory(
+                categoryGroupCode = any(),
+                x = any(),
+                y = any(),
+                radius = any(),
+                page = any(),
+                size = any()
+            )
+        } answers {
+            callCount++
+            transactionActiveDuringFetch.add(TransactionSynchronizationManager.isActualTransactionActive())
+            KakaoPlaceSearchResponse(
+                meta = KakaoPlaceMeta(total_count = 0, pageable_count = 0, is_end = true),
+                documents = emptyList()
+            )
+        }
+
+        val service = PlaceSyncServiceImpl(
+            kakaoPlaceClient = kakaoPlaceClient,
+            placeSyncWriter = placeSyncWriter,
+            placeSyncFilter = PlaceSyncFilter(),
+            placeSearchPointGenerator = PlaceSearchPointGenerator(),
+            placeDistanceCalculator = PlaceDistanceCalculator()
+        )
+
+        service.sync()
+
+        // 검색 좌표 7x7=49개 x 카테고리 8개 = 392회 호출되어야 한다 (is_end=true 이므로 페이지당 1회)
+        assertEquals(392, callCount, "외부 API 호출 횟수가 예상과 다르다")
+        assertTrue(
+            transactionActiveDuringFetch.all { !it },
+            "외부 API 호출 중에는 활성 트랜잭션이 없어야 한다 (트랜잭션이 커넥션을 점유한 채 대기하면 안 됨)"
+        )
+
+        val reloaded = placeRepository.findById(requireNotNull(stalePlace.id)).orElseThrow()
+        assertFalse(reloaded.isActive, "동기화 대상에서 빠진 기존 장소는 PlaceSyncWriter의 트랜잭션 안에서 비활성화·커밋되어야 한다")
+    }
+}


### PR DESCRIPTION
## 📃 작업내용
`PlaceSyncService.sync()`가 카카오 장소 검색 API 호출(검색 좌표 49개 × 카테고리 8개 × 최대 3페이지 = 최대 1,176회의 동기 블로킹 HTTP 호출)을 DB 반영과 함께 하나의 `@Transactional` 안에서 처리하고 있어서, 외부 API 응답을 기다리는 동안 DB 커넥션을 계속 점유하는 구조였습니다. 외부 호출 단계와 DB 반영 단계를 분리했습니다.

## 🙋‍♂️ 참고사항
- DB 반영(생성/갱신/비활성화)만 담당하는 `PlaceSyncWriter`를 새로 분리하고, 여기에만 `@Transactional`을 걸었습니다. `PlaceSyncServiceImpl.sync()` 자체는 더 이상 트랜잭션을 걸지 않고, 카카오 API 호출을 모두 끝낸 뒤 `PlaceSyncWriter.write()`를 한 번 호출하는 구조로 바꿨습니다.
- `PlaceSyncTransactionScopeTest`를 추가해 "외부 API 호출 시점에는 활성 트랜잭션이 없다"는 것과 "DB 반영은 정상적으로 커밋된다"는 것을 실제 DB(H2) + 트랜잭션 상태 조회(`TransactionSynchronizationManager`)로 검증했습니다.
  - 검증 방법: 수정 전 상태를 재현하기 위해 `sync()` 호출을 트랜잭션으로 감싸서 실행해보니 이 테스트가 실패하는 것을 확인했고(= 이 테스트가 실제로 문제를 잡아낸다는 뜻), 원래 코드(트랜잭션 없이 fetch)로 되돌리면 통과하는 것을 확인했습니다.
- 기존 `PlaceSyncServiceImplTest`는 DB 반영 검증 대신 "수집된 문서를 PlaceSyncWriter로 올바르게 위임하는지"를 검증하도록 정리했고, DB 생성/갱신/비활성화 로직 검증은 새로 만든 `PlaceSyncWriterTest`로 옮겼습니다.
- 외부 API 호출 횟수(최대 1,176회)나 스케줄러 주기(주 1회) 자체는 바뀌지 않았습니다. 이번 변경은 그 호출들이 DB 트랜잭션(커넥션)을 붙잡은 채로 실행되지 않도록 범위만 좁힌 것입니다.
- API 응답/스케줄러 동작(생성/갱신/비활성화 결과)에는 변화가 없습니다.
- 전체 테스트(`./gradlew test`, 201개) 통과 확인했습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
