### PR TITLE
Prometheus 메트릭 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // Monitoring
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
     // JWT
     implementation "io.jsonwebtoken:jjwt-api:0.12.6"
     runtimeOnly "io.jsonwebtoken:jjwt-impl:0.12.6"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,10 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health,info,prometheus
+  metrics:
+    tags:
+      application: goms-server-v3
 
 springdoc:
   api-docs:

--- a/src/test/kotlin/com/example/team/haribo/goms/global/monitoring/ActuatorEndpointTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/global/monitoring/ActuatorEndpointTest.kt
@@ -1,0 +1,84 @@
+package com.example.team.haribo.goms.global.monitoring
+
+import com.example.team.haribo.goms.global.log.RequestLoggingFilter
+import com.example.team.haribo.goms.global.security.SecurityConfig
+import com.example.team.haribo.goms.global.jwt.JwtProvider
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.boot.SpringBootConfiguration
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ActuatorEndpointTestApplication::class],
+    properties = [
+        "spring.profiles.active=",
+        "jwt.secret=actuator-test-secret-must-be-at-least-32-bytes",
+        "jwt.access-exp-seconds=300",
+        "jwt.refresh-exp-seconds=3600",
+        "management.health.redis.enabled=false",
+        "spring.autoconfigure.exclude=" +
+            "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration," +
+            "org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration," +
+            "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration," +
+            "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration," +
+            "org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration"
+    ]
+)
+class ActuatorEndpointTest @Autowired constructor(
+    @LocalServerPort private val port: Int,
+    private val jwtProvider: JwtProvider
+) {
+
+    private val httpClient = HttpClient.newHttpClient()
+
+    @Test
+    fun `actuator endpoints require authentication`() {
+        assertEquals(401, get("/actuator/health").statusCode())
+        assertEquals(401, get("/actuator/info").statusCode())
+        assertEquals(401, get("/actuator/prometheus").statusCode())
+    }
+
+    @Test
+    fun `authenticated requests can access the exposed actuator endpoints`() {
+        val accessToken = jwtProvider.createAccessToken(1L, "ROLE_STUDENT")
+
+        val health = get("/actuator/health", accessToken)
+        val info = get("/actuator/info", accessToken)
+        val prometheus = get("/actuator/prometheus", accessToken)
+
+        assertEquals(200, health.statusCode())
+        assertEquals(200, info.statusCode())
+        assertEquals(200, prometheus.statusCode())
+        assertTrue(prometheus.body().contains("# HELP"))
+        assertTrue(prometheus.body().contains("application=\"goms-server-v3\""))
+    }
+
+    private fun get(path: String, accessToken: String? = null): HttpResponse<String> {
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("http://localhost:$port$path"))
+            .apply {
+                if (accessToken != null) {
+                    header("Authorization", "Bearer $accessToken")
+                }
+            }
+            .GET()
+            .build()
+
+        return httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+    }
+}
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@Import(SecurityConfig::class, RequestLoggingFilter::class)
+private class ActuatorEndpointTestApplication


### PR DESCRIPTION
## 📃 작업내용
- Actuator 및 Prometheus 메트릭 의존성 추가
- `/actuator/prometheus` 엔드포인트 활성화
- 애플리케이션 공통 메트릭 태그 추가

## 🙋‍♂️ 참고사항
- 기존 SecurityFilterChain을 유지해 Actuator 엔드포인트는 인증이 필요합니다.
- 인프라 설정과 기존 `/api/v3/**` 인증/인가 정책은 변경하지 않았습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요?
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 테스트
- `./gradlew.bat build --no-daemon` 성공
- 실제 HTTP 요청으로 Actuator 3개 엔드포인트 및 인증 정책 검증
