### PR TITLE
Actuator 접근 설정 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
 
 networks:
   default:

--- a/src/main/kotlin/com/example/team/haribo/goms/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/team/haribo/goms/global/security/SecurityConfig.kt
@@ -82,6 +82,11 @@ class SecurityConfig {
                 it.requestMatchers("/swagger-ui.html").permitAll()
                 it.requestMatchers("/swagger-ui/**").permitAll()
 
+                // ACTUATOR
+                it.requestMatchers("/actuator/health").permitAll()
+                it.requestMatchers("/actuator/info").permitAll()
+                it.requestMatchers("/actuator/prometheus").permitAll()
+
                 // AUTH
                 it.requestMatchers("/api/v3/auth/email-verifications/send").permitAll()
                 it.requestMatchers("/api/v3/auth/email-verifications/confirm").permitAll()

--- a/src/test/kotlin/com/example/team/haribo/goms/global/monitoring/ActuatorEndpointTest.kt
+++ b/src/test/kotlin/com/example/team/haribo/goms/global/monitoring/ActuatorEndpointTest.kt
@@ -42,25 +42,31 @@ class ActuatorEndpointTest @Autowired constructor(
     private val httpClient = HttpClient.newHttpClient()
 
     @Test
-    fun `actuator endpoints require authentication`() {
-        assertEquals(401, get("/actuator/health").statusCode())
-        assertEquals(401, get("/actuator/info").statusCode())
-        assertEquals(401, get("/actuator/prometheus").statusCode())
-    }
-
-    @Test
-    fun `authenticated requests can access the exposed actuator endpoints`() {
-        val accessToken = jwtProvider.createAccessToken(1L, "ROLE_STUDENT")
-
-        val health = get("/actuator/health", accessToken)
-        val info = get("/actuator/info", accessToken)
-        val prometheus = get("/actuator/prometheus", accessToken)
+    fun `actuator endpoints are accessible without authentication`() {
+        val health = get("/actuator/health")
+        val info = get("/actuator/info")
+        val prometheus = get("/actuator/prometheus")
 
         assertEquals(200, health.statusCode())
         assertEquals(200, info.statusCode())
         assertEquals(200, prometheus.statusCode())
         assertTrue(prometheus.body().contains("# HELP"))
         assertTrue(prometheus.body().contains("application=\"goms-server-v3\""))
+    }
+
+    @Test
+    fun `authenticated requests can access the exposed actuator endpoints`() {
+        val accessToken = jwtProvider.createAccessToken(1L, "ROLE_STUDENT")
+
+        assertEquals(200, get("/actuator/health", accessToken).statusCode())
+        assertEquals(200, get("/actuator/info", accessToken).statusCode())
+        assertEquals(200, get("/actuator/prometheus", accessToken).statusCode())
+    }
+
+    @Test
+    fun `protected endpoints still require authentication`() {
+        assertEquals(401, get("/api/v3/member/withdraw").statusCode())
+        assertEquals(401, get("/actuator/beans").statusCode())
     }
 
     private fun get(path: String, accessToken: String? = null): HttpResponse<String> {


### PR DESCRIPTION
## 📃 작업내용
- Actuator health, info, prometheus 엔드포인트 인증 예외 추가
- Spring Boot app 포트를 localhost로 제한
- Actuator 및 기존 보호 API 회귀 테스트 보강

## 🙋‍♂️ 참고사항
- MariaDB 3306, Redis 6379 포트와 기존 volume 및 network 설정은 변경하지 않았습니다.
- Nginx의 127.0.0.1:8080 reverse proxy 및 동일 VM Prometheus 접근과 호환됩니다.

## ✅ PR 체크리스트

- [ ] 문서 변경 필요 여부 확인
- [ ] 관련 팀원 공유 여부 확인
- [x] 작업한 설정과 테스트가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 테스트
- gradlew.bat clean build --no-daemon 성공
- docker compose config 성공
- git diff --check 통과